### PR TITLE
a[download] demo browser support should be updated

### DIFF
--- a/html5-demos.appspot.com/static/a.download.html
+++ b/html5-demos.appspot.com/static/a.download.html
@@ -253,7 +253,7 @@ h1 a:hover {
     <p>'Create file' creates a .txt file from the <code>contenteditable</code> region's content. This is done
     by using <code>window.URL.createObjectURL()</code>. That generated file can be named and saved to
     the user's machine by setting the  <code>download</code> attribute on a link.</p>
-    <p><b>Browser support</b>: right now, only Chrome dev channel (14.0.835.15+) supports this attribute.</p>
+    <p><b>Browser support</b>: Chrome 14+, Firefox 20+ and Opera 15+</p>
   </div>
 </details>
 


### PR DESCRIPTION
https://github.com/ebidel/html5demos/blob/master/html5-demos.appspot.com/static/a.download.html

Line 256 should be updated:
<code>&lt;p>&lt;b>Browser support&lt;/b>: right now, only Chrome dev channel (14.0.835.15+) supports this attribute.&lt;/p></code>

The download attribute now works in Chrome stable channel, Firefox and Opera (and maybe more).
